### PR TITLE
Add pool total tracking with negative balance warnings in horizon view

### DIFF
--- a/frontend/src/lib/i18n/translations/en.json
+++ b/frontend/src/lib/i18n/translations/en.json
@@ -187,6 +187,10 @@
   "overview.noPreviousPayment": "No previous payment",
   "overview.noNextPayment": "No next payment",
   "overview.includeDrafts": "Include drafts",
+  "overview.currentTotal": "Current Total",
+  "overview.projectedTotal": "Projected Total",
+  "overview.minimumTotal": "Minimum",
+  "overview.poolNegativeWarning": "Pool balance goes negative in this period!",
 
   "cashflow.title": "Cashflow Planning",
   "cashflow.failedToLoad": "Failed to load cashflow projection",

--- a/frontend/src/lib/i18n/translations/fr.json
+++ b/frontend/src/lib/i18n/translations/fr.json
@@ -187,6 +187,10 @@
   "overview.noPreviousPayment": "Aucun paiement précédent",
   "overview.noNextPayment": "Aucun paiement suivant",
   "overview.includeDrafts": "Inclure les brouillons",
+  "overview.currentTotal": "Total actuel",
+  "overview.projectedTotal": "Total projeté",
+  "overview.minimumTotal": "Minimum",
+  "overview.poolNegativeWarning": "Le solde du pot commun devient négatif sur cette période !",
 
   "cashflow.title": "Planification de trésorerie",
   "cashflow.failedToLoad": "Échec du chargement de la projection de trésorerie",


### PR DESCRIPTION
- Add summary banner showing current, projected, and minimum pool totals
- Display distinct dashed Total line in pool ownership chart
- Highlight negative periods with red zone shading on specific date ranges
- Show warning badge when pool balance goes negative in projection
- Support focus mode: stats and red zones reflect focused participant's ownership
- Use stepped lines for accurate financial data representation
- Hide "Today" line when date range doesn't include current date
- Remove duplicate total row from table footer
- Clean up unused variables and CSS selectors