### PR TITLE
Fix app stuck on loading spinner: pin adapter-node 5.5.4 + CI smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,39 @@ jobs:
       - name: Run frontend linter
         working-directory: ./frontend
         run: npm run format:check
+
+      # Guards against adapter-node regressions where the production server
+      # fails to serve static assets (e.g. adapter-node 5.5.5+ bundled the
+      # request handler into a nested chunk, breaking import.meta.url-based
+      # asset path resolution). This is invisible to `npm run build` and
+      # `npm run check` because the build succeeds; only running the server
+      # and requesting an asset catches it. Symptom in prod: HTML 200 but
+      # every /_app/*.js 404s, so the app hangs on the loading spinner.
+      - name: Smoke test - production server serves static assets
+        working-directory: ./frontend
+        run: |
+          npm run build
+          PORT=3000 HOST=127.0.0.1 node build &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+
+          # Wait (up to 30s) for the server to accept connections
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://127.0.0.1:3000/; then break; fi
+            sleep 1
+          done
+
+          # Pick a real content-hashed entry asset from the build output
+          asset_file=$(ls build/client/_app/immutable/entry/*.js | head -1)
+          asset_path=${asset_file#build/client}
+          echo "Checking immutable asset: $asset_path"
+
+          code_asset=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:3000${asset_path}")
+          code_robots=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:3000/robots.txt")
+          echo "asset=$code_asset robots.txt=$code_robots"
+
+          if [ "$code_asset" != "200" ] || [ "$code_robots" != "200" ]; then
+            echo "::error::Production server is not serving static assets (likely an adapter-node regression). immutable asset=$code_asset, robots.txt=$code_robots — expected 200 for both."
+            exit 1
+          fi
+          echo "Static asset serving OK."

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^9.39.2",
         "@sveltejs/adapter-auto": "^7.0.1",
-        "@sveltejs/adapter-node": "^5.5.5",
+        "@sveltejs/adapter-node": "5.5.4",
         "@sveltejs/kit": "^2.66.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@testing-library/svelte": "^5.3.1",
@@ -1084,28 +1084,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
-      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1544,16 +1522,15 @@
       }
     },
     "node_modules/@sveltejs/adapter-node": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.5.tgz",
-      "integrity": "sha512-F3zmmy85l21eXzo3FjCR0IVnVokaDU0RNczOorPyxDmhKfFH+biQMoHoOSTjQyUN64MH/MxywGHDn/fZnLVK1Q==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.4.tgz",
+      "integrity": "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
-        "@rollup/plugin-replace": "^6.0.3",
         "rollup": "^4.59.0"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^9.39.2",
     "@sveltejs/adapter-auto": "^7.0.1",
-    "@sveltejs/adapter-node": "^5.5.5",
+    "@sveltejs/adapter-node": "5.5.4",
     "@sveltejs/kit": "^2.66.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@testing-library/svelte": "^5.3.1",


### PR DESCRIPTION
## Problem

The deployed app loads only the spinner and never hydrates. Every `/_app/*.js`, CSS, and static file (favicon, robots.txt) returns 404, so the entry-module `import()` fails and hydration never starts.

## Root cause

A Dependabot bump moved `@sveltejs/adapter-node` from 5.5.3 → **5.5.5**. Starting in 5.5.5, the adapter bundles the request handler into a **nested chunk** (`server/chunks/handler-*.js`) instead of the output-root `handler.js`. The static-file middleware resolves its asset directory from `import.meta.url`, so it now looks for the client assets next to that nested chunk (a directory that does not exist) instead of at the output root. `serve()` sees the missing dir, returns `undefined`, and **static serving is silently dropped from the middleware chain** — so all assets 404.

Verified the regression is present in **5.5.5, 5.5.6, and 5.5.7** (latest), and absent in 5.5.4. Confirmed on the running container (the expected client dir was missing next to the nested chunk) and reproduced deterministically from source.

## Fix

- Pin `@sveltejs/adapter-node` to **5.5.4** exactly (no `^`/`~`, since all of 5.5.5–5.5.7 are broken). Runtime-verified: immutable assets now serve `200 text/javascript`.
- Add a **CI smoke test** in the frontend job: build the production bundle, run `node build`, and assert a hashed immutable asset + `robots.txt` both return 200. This failure mode is invisible to `npm run build`/`npm run check` (the build succeeds); only running the server catches it.

## Deploy

After merge, `docker-build.yml` republishes `ghcr.io/bassdr/bonscompte-frontend:latest`. On the host: `docker compose pull frontend && docker compose up -d frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
