### PR TITLE
Fix validate-bash hook blocking on incidental path mentions

### DIFF
--- a/.claude/scripts/validate-bash.sh
+++ b/.claude/scripts/validate-bash.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
+# PreToolUse hook for Bash commands.
+#
+# Goal: keep the agent from reading/searching/listing generated artifact
+# directories (build output, caches, vendored deps) so it doesn't waste time
+# and context spelunking through them.
+#
+# Important: we only apply the deny-list to commands that actually READ or
+# TRAVERSE the filesystem (cat, grep, ls, find, ...). We do NOT block a path
+# just because the string appears somewhere on the command line — otherwise a
+# commit message, PR body, heredoc, or a build tool invocation like
+# `npm run build` / `node build` gets falsely rejected. Matching is done per
+# command segment (split on pipes/`&&`/`;`/...) so `find . | grep build/` is
+# still caught while `git commit -m "...build/..."` is not.
+
 # Read JSON input from stdin
 INPUT=$(cat)
 
-# Extract the command from JSON - correct path
+# Extract the command from JSON
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 # If no command found, allow it
@@ -11,7 +25,7 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Define forbidden patterns
+# Forbidden paths (generated/artifact directories and noisy file types).
 FORBIDDEN_PATTERNS=(
   "frontend/\.svelte-kit"
   "backend/target"
@@ -25,13 +39,52 @@ FORBIDDEN_PATTERNS=(
   "\.log$"
 )
 
-# Check if command contains any forbidden patterns
-for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
-  if echo "$COMMAND" | grep -qE "$pattern"; then
-    echo "ERROR: Access to '$pattern' is blocked by security policy" >&2
-    exit 2  # Exit code 2 = blocking error
+# Commands that read/search/list the filesystem. The deny-list only applies
+# when a segment's leading command is one of these.
+READ_CMDS='cat|bat|head|tail|less|more|nl|od|xxd|hexdump|strings|grep|egrep|fgrep|zgrep|rg|ag|ack|ls|ll|find|fd|tree|awk|gawk|sed|cut|sort|uniq|wc|stat|file|diff|colordiff|vim|vi|view|nano|emacs|readlink|realpath'
+
+# Prefixes that wrap a real command; skip them to find the actual command word.
+is_prefix() {
+  case "$1" in
+    sudo | command | time | nice | nohup | env | xargs | then | do | else | exec | builtin) return 0 ;;
+    *=*) return 0 ;; # leading VAR=value environment assignment
+    *) return 1 ;;
+  esac
+}
+
+# Split the command into segments on shell separators so each invocation is
+# inspected on its own. This is a heuristic (not a real shell parser) and is
+# intentionally biased toward allowing rather than blocking.
+SEGMENTS=$(printf '%s\n' "$COMMAND" | sed -E 's/(\|\||&&|\||;|&|`|\$\()/\n/g')
+
+while IFS= read -r segment; do
+  # Trim leading whitespace
+  seg="${segment#"${segment%%[![:space:]]*}"}"
+  [ -z "$seg" ] && continue
+
+  # Find the leading command word, skipping env assignments and wrapper prefixes
+  read -ra toks <<<"$seg"
+  cmd=""
+  for t in "${toks[@]}"; do
+    if is_prefix "$t"; then
+      continue
+    fi
+    cmd="$t"
+    break
+  done
+  [ -z "$cmd" ] && continue
+  cmd="${cmd##*/}" # strip any path, e.g. /bin/cat -> cat
+
+  # Only enforce the deny-list for read/search/list commands
+  if [[ "$cmd" =~ ^(${READ_CMDS})$ ]]; then
+    for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+      if echo "$seg" | grep -qE "$pattern"; then
+        echo "ERROR: Reading '$pattern' is blocked by security policy (generated artifact)" >&2
+        exit 2 # Exit code 2 = blocking error
+      fi
+    done
   fi
-done
+done <<<"$SEGMENTS"
 
 # Command is clean, allow it
 exit 0


### PR DESCRIPTION
## Problem

The `PreToolUse` Bash guard (`.claude/scripts/validate-bash.sh`) searched the **entire command line** for forbidden artifact paths (`build`, `dist`, `backend/target`, `frontend/.svelte-kit`, …) using an unanchored substring match. So it blocked *any* command that merely **mentioned** one of those strings, even when nothing was reading a generated directory:

- commit messages / PR bodies that reference `build/`
- heredoc file content (e.g. a CI YAML being written)
- legitimate build invocations like `node build` / `npm run build`

This forced ugly workarounds (renaming paths, obfuscating strings) to run perfectly safe commands.

## Fix

Apply the deny-list **only to commands that actually read/search/traverse the filesystem** (`cat`, `grep`, `ls`, `find`, `sed`, …), evaluated **per command segment** (split on `|`, `&&`, `;`, …). Leading env assignments and wrapper prefixes (`sudo`, `env`, `xargs`, …) are skipped to find the real command word.

Result:
- ✅ `git commit -m "...build/..."`, `gh pr create`, `node build`, `npm run build`, `docker compose build` — allowed
- ⛔ `cat build/handler.js`, `grep -r x build/`, `ls build/client`, `find . | xargs cat backend/target/x` — still blocked

The forbidden-path list itself is unchanged; only the gating logic changed.

## Known limitation

Matching is a heuristic, not a shell parser, so a literal `|` inside a quoted string can still split into a phantom segment and cause a rare false block (e.g. a commit message literally containing `| grep build/`). This errs toward safety and is far rarer than the previous behavior.

## Testing

16 cases (8 allow / 8 block) all pass. Verified the previously-failing real commands (commit with `build/` in the message, PR creation with `build/` in the body) now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
