### PR TITLE
Move adapter-node forward to ^5.5.7 (un-freeze the 5.5.4 over-pin)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^9.39.2",
         "@sveltejs/adapter-auto": "^7.0.1",
-        "@sveltejs/adapter-node": "5.5.4",
+        "@sveltejs/adapter-node": "^5.5.7",
         "@sveltejs/kit": "^2.66.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@testing-library/svelte": "^5.3.1",
@@ -1084,6 +1084,28 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1522,15 +1544,16 @@
       }
     },
     "node_modules/@sveltejs/adapter-node": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.4.tgz",
-      "integrity": "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.7.tgz",
+      "integrity": "sha512-uOfc9eVlI3A37RRSaKcgrheBYPrfJwC9VMqDp8x/O6tlKdcLLvHThSWD0KNIbjQ/d+7bwLGx3vx6aowAcRfd2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "rollup": "^4.59.0"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^9.39.2",
     "@sveltejs/adapter-auto": "^7.0.1",
-    "@sveltejs/adapter-node": "5.5.4",
+    "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/kit": "^2.66.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@testing-library/svelte": "^5.3.1",


### PR DESCRIPTION
## Context

PR #285 fixed the production spinner outage by pinning `@sveltejs/adapter-node` to **5.5.4** exactly, on the belief that 5.5.5, 5.5.6 **and** 5.5.7 were all broken. That belief was wrong.

## What I re-tested

For each release: `npm run build` → `node build` → `curl` a hashed immutable asset + `robots.txt`.

| version | hashed asset | verdict |
|---------|--------------|---------|
| 5.5.4   | `200`        | ok |
| **5.5.5** | `404`      | **BROKEN — this is the version that shipped in the outage image** |
| 5.5.6   | `200`        | fixed upstream |
| 5.5.7   | `200`        | fixed upstream |

The static-asset regression was **5.5.5-only** and was **already fixed in 5.5.6**. The earlier "5.5.6/5.5.7 also broken" finding was a stale-`build/` testing artifact (versions swapped without rebuilding).

## Change

- `@sveltejs/adapter-node`: `5.5.4` (frozen) → `^5.5.7` (latest + future patches).
- The CI production smoke test added in #285 is the safety net: if any future adapter release breaks static serving again, the smoke test fails the build.

## Security

No impact. adapter-node no longer depends on esbuild at all, so this does **not** touch the one open Dependabot alert (esbuild 0.27.3, low) — that comes from `vite`'s bundled esbuild and is independent of the adapter version. Verified: `git diff` of `package-lock.json` changes no esbuild entries.

## Deploy

After merge, `docker-build.yml` republishes `ghcr.io/bassdr/bonscompte-frontend:latest`; on the host `docker compose pull frontend && docker compose up -d frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)