### PR TITLE
Reduce Dependabot churn: group majors per ecosystem + auto-merge patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,18 +15,20 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      # Group all minor and patch updates together
+      # Low-risk updates: batched into one PR and auto-merged once CI
+      # (incl. the production smoke test) passes. See dependabot-auto-merge.yml.
       frontend-minor-patch:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-      # Group dev dependencies separately
-      frontend-dev:
+      # Breaking updates: batched into one PR but left for manual review.
+      frontend-major:
         patterns:
           - "*"
-        dependency-type: "development"
+        update-types:
+          - "major"
 
   - package-ecosystem: "cargo"
     directory: "/backend/"
@@ -34,18 +36,17 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
-      # Group all minor and patch updates together
       backend-minor-patch:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-      # Group dev dependencies separately
-      backend-dev:
+      backend-major:
         patterns:
           - "*"
-        dependency-type: "development"
+        update-types:
+          - "major"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -53,6 +54,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 3
     groups:
-      root-all:
+      root-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      root-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot auto-merge
+
+# Auto-merge low-risk Dependabot PRs (patch and minor bumps) once all
+# required status checks pass — including the production smoke test in
+# test.yml that catches "a dependency bump silently breaks the running
+# app" (the failure mode behind the adapter-node 5.5.5 outage).
+#
+# Major bumps are intentionally NOT auto-merged: they land in the
+# *-major Dependabot groups and wait for a human to review them.
+#
+# Uses pull_request_target so the job runs with the base-repo token and
+# the workflow definition from main (not from the PR), which is the
+# documented, safe pattern for acting on Dependabot PRs. We never check
+# out or execute the PR's code here.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # For grouped PRs, update-type is the highest semver bump in the group.
+      # The frontend/backend/root *-minor-patch groups therefore report at
+      # most "semver-minor", so this never fires for a group containing a major.
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+              steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

The weekly Dependabot flow was unmanageable: ~12 open PRs at once, each needing a manual merge → rebase the queue → wait for CI → repeat. And a "cosmetic" patch bump (adapter-node 5.5.5) silently broke production because it sailed through CI unreviewed.

## Changes

### 1. `dependabot.yml` — fewer, clearer PRs
- Each ecosystem now has exactly **two** groups: `*-minor-patch` (low-risk) and `*-major` (breaking). A busy week yields at most one safe PR + one breaking PR per ecosystem, instead of ~8 individual major PRs.
- Removed the `frontend-dev` / `backend-dev` groups: they overlapped the minor-patch groups (both `patterns: ["*"]`) and only ever caught dev **major** updates — confusing and unintended.

### 2. `dependabot-auto-merge.yml` — kill the manual merge loop
- Auto-merges patch/minor (and Actions) group PRs once **all required checks pass**. Dependabot then handles the rebase queue itself.
- **Majors are never auto-merged** — they land in the `*-major` groups, whose grouped `update-type` is `semver-major`, which the workflow skips. They wait for human review.

## Why this is safe now
- `test.yml` gained a **production smoke test** (`node build` + assert a hashed immutable asset and `robots.txt` return 200) — exactly the failure class that the 5.5.5 bump slipped past. Auto-merge can't complete until it's green.
- `allow_auto_merge` is already enabled on the repo; branch protection already requires the test jobs. Nothing merges before checks pass.
- `pull_request_target` runs the workflow from `main` (not the PR) and never checks out PR code — the documented, safe pattern for acting on Dependabot PRs.

## Follow-up (manual, not in this PR)
- Existing open PRs won't be regrouped retroactively; Dependabot will reorganize them on the next weekly run (or `@dependabot recreate`).
- The ~8 open **major** PRs still need individual review. Riskiest: `@lucide/svelte` 0.576→1.x (import-path API change) and `sqlx` 0.8→0.9 (query layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)