### PR TITLE
Harden backend Docker build against crates.io HTTP/2 flakes

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,12 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
+# Resilient crates.io downloads: HTTP/1.1 avoids the "HTTP2 framing layer
+# (Connection reset by peer)" errors seen intermittently on CI runners, and
+# retry transient network failures instead of failing the whole build.
+ENV CARGO_NET_RETRY=10
+ENV CARGO_HTTP_MULTIPLEXING=false
+
 # Copy manifests first for layer caching
 COPY Cargo.toml Cargo.lock ./
 


### PR DESCRIPTION
## Problem

The multi-arch backend image build intermittently fails while downloading crates from the registry — e.g. on #290's CI run:

```
download of fi/nd/find-msvc-tools failed
curl failed
[16] Error in the HTTP2 framing layer (Send failure: Connection reset by peer)
```

This is a transient network fault (cargo's HTTP/2 connection to crates.io getting reset mid-download), **not** a dependency problem. But it fails the whole build, cancels the sibling arch, and blocks merges — needing a manual re-run each time.

## Fix

Two cargo env vars in the builder stage of `backend/Dockerfile`:

- **`CARGO_HTTP_MULTIPLEXING=false`** — forces HTTP/1.1, which avoids the HTTP/2 framing-layer resets specifically. Marginally slower downloads, far more reliable.
- **`CARGO_NET_RETRY=10`** — retries transient download failures (cargo default is only 3).

No code or dependency changes; build output is byte-for-byte the same when the network is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)