### PR TITLE
CodeQL: pre-fetch Rust deps instead of full build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,9 +30,13 @@ jobs:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
+      # CodeQL analyzes Rust with build-mode "none" (it resolves the crate
+      # graph itself), so a full `cargo build` does not feed the database.
+      # Pre-fetching dependencies makes the registry + crate sources available
+      # during extraction, which improves call-target resolution quality.
       - if: matrix.language == 'rust'
         working-directory: backend
-        run: cargo build --release
+        run: cargo fetch
 
       # For TypeScript: analyze and upload directly (no filtering needed)
       - if: matrix.language == 'typescript'


### PR DESCRIPTION
## Why

The Rust CodeQL run reports **"Low Rust analysis quality"** — call-target resolution 47% (threshold 50%). The job also runs `cargo build --release`, but CodeQL analyzes Rust in **build-mode `none`** (it resolves the crate graph itself), so that build never feeds the database; it just adds minutes.

## Change

Replace `cargo build --release` with `cargo fetch`. Fetching makes the registry index and crate sources available during extraction, giving the extractor the best shot at resolving call targets — and the job gets faster (no compile).

## Honest expectations

This is a **minor cleanup, not a guaranteed fix**. Most of the unresolved-call share comes from macro-, generic-, and async-heavy code (`sqlx`/`serde`/`axum`/`tokio`) that the still-maturing Rust extractor can't fully follow. It may nudge past the 50% threshold; it may not. Either way the scan completes and uploads findings as before — this metric is advisory, which is why CodeQL is (and should stay) a non-required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)