### PR TITLE
Give Docker build jobs a stable check name

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,10 @@ env:
 
 jobs:
   build:
+    # Stable check name so branch-protection required checks don't depend on
+    # the matrix's dockerfile path / build-args (which GitHub would otherwise
+    # bake into the auto-generated context string).
+    name: Docker image (${{ matrix.service }})
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why

The `build` job in `docker-build.yml` has no explicit `name:`, so GitHub derives the status-check context by joining all matrix values:

- `build (backend, ./backend/Dockerfile, ./backend)`
- `build (frontend, ./frontend/Dockerfile, ./frontend, VITE_API_BASE=/api)`

Those strings change whenever the matrix changes (dockerfile path, build-args, etc.). If they're used as **required** checks in the branch ruleset, any such change silently renames the context — and a required check that never reports under its old name blocks every PR.

## Change

Name the job `Docker image (${{ matrix.service }})`, giving stable contexts:

- `Docker image (backend)`
- `Docker image (frontend)`

These are independent of paths/build-args and are what we'll add to the "Restrict main" ruleset as required checks (a separate settings change, not in this PR).

No behavior change to the build itself.

## Follow-up

After this merges, add `Docker image (backend)` and `Docker image (frontend)` to the ruleset's required status checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)