### PR TITLE
Fix Docker build flakiness at the root: native per-arch runners + Docker Hub auth

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,46 +10,234 @@ on:
     branches:
       - main
 
+# Avoid piling up overlapping multi-arch builds for the same ref.
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Root cause of past build flakiness:
+#   - arm64 was emulated with QEMU on an amd64 runner, so the Rust compile ran
+#     10-30x slower and the long-lived crates.io connections got reset mid-build.
+#   - multi-arch-via-QEMU + anonymous Docker Hub pulls (binfmt, buildkit, base
+#     images) hit Docker Hub rate limits / timeouts.
+# Fix: build each architecture on its NATIVE runner (no QEMU) and authenticate
+# Docker Hub pulls. Per-arch images are pushed by digest, then combined into a
+# multi-arch manifest in the publish-* jobs.
+
 jobs:
-  build:
-    # Stable check name so branch-protection required checks don't depend on
-    # the matrix's dockerfile path / build-args (which GitHub would otherwise
-    # bake into the auto-generated context string).
-    name: Docker image (${{ matrix.service }})
-    runs-on: ubuntu-latest
+  build-backend:
+    name: Build backend (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - service: backend
-            dockerfile: ./backend/Dockerfile
-            context: ./backend
-            build-args: ""
-          - service: frontend
-            dockerfile: ./frontend/Dockerfile
-            context: ./frontend
-            # Production build: use /api prefix for nginx reverse proxy
-            build-args: "VITE_API_BASE=/api"
-
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      # ghcr.io requires a lowercase image path; github.repository is mixed-case.
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}-backend" >> "$GITHUB_ENV"
+
+      # Authenticated Docker Hub pulls (base image + buildkit) avoid the
+      # anonymous rate-limit/timeout flakes. Skipped automatically when the
+      # secret is absent (e.g. fork PRs) so builds still work anonymously.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Container Registry
+      - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pull requests: build only to validate the Dockerfile (no push).
+      - name: Build (validate)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: false
+          cache-from: type=gha,scope=backend-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=backend-${{ matrix.arch }}
+
+      # Push events: build and push by digest (the manifest is assembled later).
+      - name: Build and push by digest
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=backend-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=backend-${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-backend-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-frontend:
+    name: Build frontend (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}-frontend" >> "$GITHUB_ENV"
+
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (validate)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: false
+          # Production build: use /api prefix for nginx reverse proxy
+          build-args: VITE_API_BASE=/api
+          cache-from: type=gha,scope=frontend-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=frontend-${{ matrix.arch }}
+
+      - name: Build and push by digest
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          build-args: VITE_API_BASE=/api
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=frontend-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=frontend-${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-frontend-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stable required-check name. On push it assembles the multi-arch manifest;
+  # on PRs it just gates on both architecture builds succeeding.
+  publish-backend:
+    name: Docker image (backend)
+    needs: build-backend
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+    steps:
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}-backend" >> "$GITHUB_ENV"
+
+      - name: Fail if any architecture build failed
+        if: ${{ needs.build-backend.result != 'success' }}
+        run: |
+          echo "::error::backend image build failed for one or more architectures"
+          exit 1
+
+      - name: Download digests
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-backend-*
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' && env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' }}
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' }}
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -58,9 +246,10 @@ jobs:
 
       - name: Extract metadata
         id: meta
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' }}
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.service }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -68,15 +257,85 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+      - name: Create and push manifest list
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        if: ${{ github.event_name != 'pull_request' && needs.build-backend.result == 'success' }}
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+
+  publish-frontend:
+    name: Docker image (frontend)
+    needs: build-frontend
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+    steps:
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}-frontend" >> "$GITHUB_ENV"
+
+      - name: Fail if any architecture build failed
+        if: ${{ needs.build-frontend.result != 'success' }}
+        run: |
+          echo "::error::frontend image build failed for one or more architectures"
+          exit 1
+
+      - name: Download digests
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' }}
+        uses: actions/download-artifact@v8
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          build-args: ${{ matrix.build-args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: ${{ runner.temp }}/digests
+          pattern: digests-frontend-*
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' && env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' }}
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' }}
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create and push manifest list
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        if: ${{ github.event_name != 'pull_request' && needs.build-frontend.result == 'success' }}
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Root cause (not bad luck)

The workflow built `linux/amd64,linux/arm64` from a **single amd64 runner via QEMU emulation**. That one design choice caused every flake we hit:

1. **crates.io HTTP/2 resets** (what #291 tried to mitigate): emulating the **arm64 Rust compile** runs ~10–30× slower, so the long-lived crates.io download connections sit open and get reset mid-build.
2. **Docker Hub timeouts** (what blocked #289): multi-arch-via-QEMU forces `setup-qemu` (binfmt) + `setup-buildx` (buildkit) pulls, and base-image pulls, all **anonymously** from Docker Hub → rate-limits/timeouts on shared runner IPs.

Retries (#291) treat the symptom. This removes the cause.

## Change

- **Build each arch on its native runner** — `amd64` on `ubuntu-24.04`, `arm64` on `ubuntu-24.04-arm` (free for public repos). No QEMU, no binfmt pull, native-speed Rust compile.
- Per-arch images are **pushed by digest**, then `publish-backend` / `publish-frontend` assemble the **multi-arch manifest** with the real tags (standard Docker pattern).
- **Authenticate Docker Hub pulls** when `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets exist; skipped gracefully when absent (fork PRs), so nothing hard-breaks.
- Kept the **stable required-check names** `Docker image (backend)` / `Docker image (frontend)` (the `publish-*` jobs): on push they build the manifest, on PRs they gate on both arch builds passing.
- Added a `concurrency` group so overlapping pushes for a ref don't pile up.

## Action required for full benefit
Create two repo secrets (Settings → Secrets and variables → Actions):
- `DOCKERHUB_USERNAME` — a Docker Hub username
- `DOCKERHUB_TOKEN` — a Docker Hub **access token** (free; Read-only scope is enough for pulls)

Without them the build still works (anonymous pulls, like before) but keeps the Docker Hub rate-limit exposure. With them, that exposure is gone.

## Notes
- `#291`'s cargo retry/HTTP-1.1 env vars in `backend/Dockerfile` stay as cheap defense-in-depth (native arm64 still pulls from crates.io).
- The old per-arch QEMU job is gone, so `setup-qemu` is no longer used anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)