### PR TITLE
Migrate to rand 0.10 (supersedes #281)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "log",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0"
 # Auth
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 argon2 = "0.5"
-rand = "0.8"
+rand = "0.10"
 
 # Utilities
 dotenvy = "0.15"

--- a/backend/src/auth/password.rs
+++ b/backend/src/auth/password.rs
@@ -1,8 +1,8 @@
+use argon2::password_hash::rand_core::OsRng;
 use argon2::{
     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
-use rand::rngs::OsRng;
 
 use crate::error::{AppError, AppResult};
 

--- a/backend/src/routes/participants.rs
+++ b/backend/src/routes/participants.rs
@@ -3,7 +3,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
@@ -388,10 +388,10 @@ async fn claim_participant(
 
 fn generate_invite_token() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789";
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..32)
         .map(|_| {
-            let idx = rng.gen_range(0..CHARSET.len());
+            let idx = rng.random_range(0..CHARSET.len());
             CHARSET[idx] as char
         })
         .collect()

--- a/backend/src/routes/projects.rs
+++ b/backend/src/routes/projects.rs
@@ -3,7 +3,7 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
-use rand::Rng;
+use rand::RngExt;
 use serde::Serialize;
 use sqlx::SqlitePool;
 
@@ -36,10 +36,10 @@ pub fn router() -> Router<AppState> {
 
 fn generate_invite_code() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..8)
         .map(|_| {
-            let idx = rng.gen_range(0..CHARSET.len());
+            let idx = rng.random_range(0..CHARSET.len());
             CHARSET[idx] as char
         })
         .collect()


### PR DESCRIPTION
Supersedes #281 (Dependabot's version-only bump, which left the backend failing to compile).

## Why #281 failed
`rand` 0.8 → 0.10 is a breaking API change. Dependabot bumps the version but can't migrate code, so the build broke with:
- `cannot find function thread_rng in crate rand`
- `unresolved import rand::rngs::OsRng`

## Migration
- **Invite code/token generators** (`routes/projects.rs`, `routes/participants.rs`): `thread_rng()` → `rng()`, and `gen_range()` → `random_range()`. In rand 0.10 `random_range` lives on the new `RngExt` trait, so `use rand::Rng` → `use rand::RngExt`.
- **Password salt** (`auth/password.rs`): source `OsRng` from Argon2's own re-export — `argon2::password_hash::rand_core::OsRng` — instead of `rand::rngs::OsRng`. rand 0.10 uses `rand_core 0.9`, but `argon2`/`password-hash` expects `rand_core 0.6` for `SaltString::generate`; pulling `OsRng` from Argon2 keeps the salt RNG matched to the hasher and decouples password hashing from the `rand` version entirely. No behavioral change to hashing.

## Validation
`cargo build`, `cargo clippy -- -D warnings`, and `cargo test` all pass — including `auth_tests` (register/login), which exercise salt generation + verification through the new RNG.

Close #281 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)