### PR TITLE
Bump prettier-plugin-svelte to 4.1.1 + reformat (supersedes #277)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "jsdom": "^28.1.0",
         "lint-staged": "^16.3.1",
         "prettier": "^3.9.1",
-        "prettier-plugin-svelte": "^3.4.0",
+        "prettier-plugin-svelte": "^4.1.1",
         "svelte": "^5.56.4",
         "svelte-check": "^4.7.1",
         "svelte-eslint-parser": "^1.5.1",
@@ -4228,14 +4228,17 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.0.tgz",
-      "integrity": "sha512-2lLO/7EupnjO/95t+XZesXs8Bf3nYLIDfCo270h5QWbj/vjLqmrQ1LiRk9LPggxSDsnVYfehamZNf+rgQYApZg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+      "integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "jsdom": "^28.1.0",
     "lint-staged": "^16.3.1",
     "prettier": "^3.9.1",
-    "prettier-plugin-svelte": "^3.4.0",
+    "prettier-plugin-svelte": "^4.1.1",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",
     "svelte-eslint-parser": "^1.5.1",

--- a/frontend/src/routes/approvals/[id]/+page.svelte
+++ b/frontend/src/routes/approvals/[id]/+page.svelte
@@ -178,8 +178,7 @@
               placeholder={$_('approvals.reason_placeholder', {
                 default: 'Explain your decision...'
               })}
-              rows="3"
-            ></textarea>
+              rows="3"></textarea>
           </div>
 
           <div class="action-buttons">

--- a/frontend/src/routes/projects/[id]/settings/+page.svelte
+++ b/frontend/src/routes/projects/[id]/settings/+page.svelte
@@ -555,8 +555,7 @@
           id="description"
           bind:value={description}
           rows="3"
-          placeholder={$_('projectSettings.descriptionPlaceholder')}
-        ></textarea>
+          placeholder={$_('projectSettings.descriptionPlaceholder')}></textarea>
       </div>
       <button type="submit" disabled={saving}>
         {saving ? $_('common.saving') : $_('projectSettings.saveChanges')}


### PR DESCRIPTION
Supersedes #277 (Dependabot's version-only bump, which failed `prettier --check`).

## Why #277 failed
prettier-plugin-svelte 3 → 4 changed how a closing tag is wrapped when an element has multiline attributes — `></textarea>` now stays on the last attribute's line. Dependabot bumped the plugin but didn't reformat, so `npm run format:check` flagged two files.

## Change
Bump the plugin and run `npm run format`. Only formatting changed in two files (`approvals/[id]/+page.svelte`, `projects/[id]/settings/+page.svelte`) — purely cosmetic, no behavioral diff. `format:check`, `svelte-check`, and the unit tests all pass.

Close #277 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)