### PR TITLE
Add 3-2-1 borg backup system for the SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+scripts/backup/backup.env

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,0 +1,69 @@
+# Backups (3-2-1)
+
+BonsCompte's SQLite database is backed up on a 3-2-1 scheme
+(3 copies, 2 machines, 1 offsite):
+
+| Copy | Where | What |
+|---|---|---|
+| 1 | This host, `~/backups/bonscompte/` | Last 14 daily `VACUUM INTO` snapshots (fast restores, no borg needed) |
+| 2 | `gentoo-tv.local:bonscompte-borg` | Borg archives, LAN |
+| 3 | `dracine@tau.binarybone.com:bonscompte-borg` | Borg archives, offsite |
+
+Everything lives in `scripts/backup/`:
+
+- `bonscompte-backup.sh` — the whole pipeline, run daily by cron (fcron, 03:30):
+  1. `VACUUM INTO` snapshot of the live DB (WAL-safe; the server keeps running)
+  2. `PRAGMA integrity_check` on the snapshot — a corrupt snapshot is never shipped
+  3. rotate local snapshots (keep 14)
+  4. `borg create` (zstd) to each repo, then `borg prune` (14 daily / 8 weekly /
+     24 monthly) + `borg compact`
+  5. non-zero exit if the snapshot or any remote fails; log at
+     `~/backups/bonscompte/backup.log`
+- `bonscompte-restore.sh` — `list` archives / `restore` one to a temp dir with an
+  integrity check and swap-in instructions
+- `backup.env.example` — copy to `backup.env` (git-ignored) to override paths,
+  repos, retention
+
+## Restore
+
+Quick (local snapshot, no borg):
+
+```bash
+# stop backend, then:
+cp ~/backups/bonscompte/bonscompte-<timestamp>.db backend/data/bonscompte.db
+rm -f backend/data/bonscompte.db-wal backend/data/bonscompte.db-shm
+# start backend
+```
+
+From borg (works even if this machine is gone — run on any host with the SSH key):
+
+```bash
+scripts/backup/bonscompte-restore.sh list
+scripts/backup/bonscompte-restore.sh restore                      # latest, LAN repo
+scripts/backup/bonscompte-restore.sh restore "" dracine@tau.binarybone.com:bonscompte-borg
+```
+
+The restore path was tested end-to-end on 2026-07-05: archive pulled from the
+offsite repo, `integrity_check: ok`, row counts identical to the live DB.
+
+## Encryption & keys
+
+Repos use borg **repokey** with an **empty passphrase** (same convention as the
+immich backups: nothing to type, nothing to lose). The repo key lives inside each
+repo; exported copies are kept at `~/backups/bonscompte/keys/`. To add a real
+passphrase later: `borg key change-passphrase <repo>`, then set `BORG_PASSPHRASE`
+in `backup.env`.
+
+Consequence of the empty passphrase: anyone with SSH access to a backup host can
+read the archives. Acceptable for now (both hosts are David's); revisit alongside
+issue #225 (encrypt DB).
+
+## Monitoring
+
+Cron discards stdout; failures are visible in `~/backups/bonscompte/backup.log`
+(lines containing `ERROR`/`FATAL`). Check occasionally, or wire the exit code to a
+notifier later. If this host is ever replaced, re-add the fcrontab line:
+
+```
+30 3 * * * /home/david/src/BonsCompte/scripts/backup/bonscompte-backup.sh >/dev/null 2>&1
+```

--- a/scripts/backup/backup.env.example
+++ b/scripts/backup/backup.env.example
@@ -1,0 +1,16 @@
+# Optional overrides for bonscompte-backup.sh / bonscompte-restore.sh.
+# Copy to backup.env (git-ignored) next to the scripts, or point
+# BONSCOMPTE_BACKUP_CONF at a file like this.
+
+#DB_PATH="/home/david/src/BonsCompte/backend/data/bonscompte.db"
+#LOCAL_SNAP_DIR="/home/david/backups/bonscompte"
+#LOCAL_KEEP=14
+#BORG_REPOS=(
+#  "gentoo-tv.local:bonscompte-borg"
+#  "dracine@tau.binarybone.com:bonscompte-borg"
+#)
+#PRUNE_OPTS=(--keep-daily 14 --keep-weekly 8 --keep-monthly 24)
+# Repos are borg repokey with an empty passphrase (matches the immich setup:
+# no prompt, key lives in the repo). Set this if you later add a passphrase
+# with `borg key change-passphrase`.
+#BORG_PASSPHRASE=""

--- a/scripts/backup/bonscompte-backup.sh
+++ b/scripts/backup/bonscompte-backup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# BonsCompte 3-2-1 backup: safe SQLite snapshot -> local rotation + borg to N remotes.
+# Designed to run unattended from cron on the host serving the backend.
+# Exit code is non-zero if the snapshot fails or ANY remote repo fails.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults; override any of these in backup.env next to this script
+# (or point BONSCOMPTE_BACKUP_CONF at another env file).
+DB_PATH="/home/david/src/BonsCompte/backend/data/bonscompte.db"
+LOCAL_SNAP_DIR="/home/david/backups/bonscompte"
+LOCAL_KEEP=14
+BORG_REPOS=(
+  "gentoo-tv.local:bonscompte-borg"
+  "dracine@tau.binarybone.com:bonscompte-borg"
+)
+PRUNE_OPTS=(--keep-daily 14 --keep-weekly 8 --keep-monthly 24)
+export BORG_PASSPHRASE="${BORG_PASSPHRASE:-}"
+
+CONF="${BONSCOMPTE_BACKUP_CONF:-$SCRIPT_DIR/backup.env}"
+# shellcheck source=/dev/null
+[ -f "$CONF" ] && source "$CONF"
+
+LOG_FILE="$LOCAL_SNAP_DIR/backup.log"
+mkdir -p "$LOCAL_SNAP_DIR"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+snap="$LOCAL_SNAP_DIR/bonscompte-$timestamp.db"
+
+# 1. Consistent snapshot of the live DB (WAL-safe, works while the server runs).
+if ! sqlite3 "file:$DB_PATH?mode=ro" "VACUUM INTO '$snap'"; then
+  log "FATAL: VACUUM INTO snapshot failed for $DB_PATH"
+  exit 1
+fi
+
+# 2. Verify the snapshot before trusting it as a backup.
+if [ "$(sqlite3 "$snap" 'PRAGMA integrity_check;')" != "ok" ]; then
+  log "FATAL: integrity_check failed on snapshot $snap"
+  rm -f "$snap"
+  exit 1
+fi
+log "snapshot OK: $snap ($(du -h "$snap" | cut -f1))"
+
+# 3. Rotate local snapshots (copy #1, fast restores).
+ls -1t "$LOCAL_SNAP_DIR"/bonscompte-*.db 2>/dev/null \
+  | tail -n +$((LOCAL_KEEP + 1)) | xargs -r rm --
+
+# 4. Ship to each borg repo (copies #2 and #3). Stage under a stable file name
+#    so every archive contains exactly one file: bonscompte.db
+stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+cp "$snap" "$stage/bonscompte.db"
+
+fail=0
+for repo in "${BORG_REPOS[@]}"; do
+  if (cd "$stage" && borg create --compression zstd \
+        "$repo::bonscompte-$timestamp" bonscompte.db) >>"$LOG_FILE" 2>&1; then
+    log "borg create OK -> $repo"
+    if borg prune -a 'bonscompte-*' "${PRUNE_OPTS[@]}" "$repo" >>"$LOG_FILE" 2>&1 \
+       && borg compact "$repo" >>"$LOG_FILE" 2>&1; then
+      log "borg prune+compact OK -> $repo"
+    else
+      log "WARN: prune/compact failed on $repo (backup itself succeeded)"
+    fi
+  else
+    log "ERROR: borg create FAILED -> $repo"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  log "backup finished WITH ERRORS"
+else
+  log "backup finished OK (local + ${#BORG_REPOS[@]} remotes)"
+fi
+exit "$fail"

--- a/scripts/backup/bonscompte-restore.sh
+++ b/scripts/backup/bonscompte-restore.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# BonsCompte restore helper.
+#
+#   bonscompte-restore.sh list [repo]            List available archives
+#   bonscompte-restore.sh restore [archive] [repo]
+#                                                Extract archive (default: latest)
+#                                                to a temp dir, verify integrity,
+#                                                and print swap-in instructions.
+#
+# Local snapshots (no borg needed) also live in $LOCAL_SNAP_DIR — for a quick
+# restore just stop the server and copy one over the live DB.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DB_PATH="/home/david/src/BonsCompte/backend/data/bonscompte.db"
+LOCAL_SNAP_DIR="/home/david/backups/bonscompte"
+BORG_REPOS=(
+  "gentoo-tv.local:bonscompte-borg"
+  "dracine@tau.binarybone.com:bonscompte-borg"
+)
+export BORG_PASSPHRASE="${BORG_PASSPHRASE:-}"
+
+CONF="${BONSCOMPTE_BACKUP_CONF:-$SCRIPT_DIR/backup.env}"
+# shellcheck source=/dev/null
+[ -f "$CONF" ] && source "$CONF"
+
+cmd="${1:-list}"
+
+case "$cmd" in
+  list)
+    repo="${2:-${BORG_REPOS[0]}}"
+    echo "== Archives in $repo =="
+    borg list -a 'bonscompte-*' "$repo"
+    echo
+    echo "== Local snapshots in $LOCAL_SNAP_DIR =="
+    ls -1t "$LOCAL_SNAP_DIR"/bonscompte-*.db 2>/dev/null || echo "(none)"
+    ;;
+  restore)
+    archive="${2:-}"
+    repo="${3:-${BORG_REPOS[0]}}"
+    if [ -z "$archive" ]; then
+      archive="$(borg list -a 'bonscompte-*' --short --last 1 "$repo")"
+      [ -n "$archive" ] || { echo "No archives found in $repo" >&2; exit 1; }
+      echo "No archive given; using latest: $archive"
+    fi
+    dest="$(mktemp -d /tmp/bonscompte-restore-XXXXXX)"
+    (cd "$dest" && borg extract "$repo::$archive")
+    restored="$dest/bonscompte.db"
+    [ -f "$restored" ] || { echo "Archive did not contain bonscompte.db" >&2; exit 1; }
+    check="$(sqlite3 "$restored" 'PRAGMA integrity_check;')"
+    echo "integrity_check: $check"
+    [ "$check" = "ok" ] || { echo "Restored DB FAILED integrity check" >&2; exit 1; }
+    echo
+    echo "Restored to: $restored"
+    echo "To swap it in:"
+    echo "  1. Stop the backend server"
+    echo "  2. cp '$DB_PATH' '$DB_PATH.pre-restore'   # keep the current DB just in case"
+    echo "  3. rm -f '$DB_PATH-wal' '$DB_PATH-shm'"
+    echo "  4. cp '$restored' '$DB_PATH'"
+    echo "  5. Start the backend server"
+    ;;
+  *)
+    echo "Usage: $0 list [repo] | restore [archive] [repo]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Daily automated backup of `backend/data/bonscompte.db` on a 3-2-1 scheme: local `VACUUM INTO` snapshots (WAL-safe, integrity-checked, keep 14) + borg repos on gentoo-tv.local (LAN) and tau.binarybone.com (offsite)
- Retention 14 daily / 8 weekly / 24 monthly with prune + compact after each run; non-zero exit if any leg fails
- Restore helper (`scripts/backup/bonscompte-restore.sh`) lists archives, extracts with an integrity check, and prints swap-in steps
- Repos use repokey with empty passphrase (same convention as the immich backups); keys exported to `~/backups/bonscompte/keys/`
- Docs in `docs/BACKUPS.md`; `backup.env` is git-ignored for local overrides

## Verification
- First backup ran to both remotes; archive restored from the **offsite** repo: `PRAGMA integrity_check` ok, row counts identical to the live DB
- Scheduled via fcron daily at 03:30 (already installed on the app host)

Closes #68 (already closed manually — this is the implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)